### PR TITLE
Print version info, not index values during error scenarios

### DIFF
--- a/src/migration.ts
+++ b/src/migration.ts
@@ -326,8 +326,10 @@ export class Migration {
           currentVersion = self.list[i + 1].version;
           await updateVersion();
         } catch (e) {
-          this.options.
-            logger('error', `Encountered an error while migrating from ${i} to ${i + 1}`);
+          const prevVersion = self.list[i].version;
+          const destVersion = self.list[i + 1].version;
+          this.options.logger(
+            'error', `Encountered an error while migrating from ${prevVersion} to ${destVersion}`);
           throw e;
         }
       }
@@ -338,8 +340,10 @@ export class Migration {
           currentVersion = self.list[i - 1].version;
           await updateVersion();
         } catch (e) {
-          this.options.
-            logger('error', `Encountered an error while migrating from ${i} to ${i - 1}`);
+          const prevVersion = self.list[i].version;
+          const destVersion = self.list[i - 1].version;
+          this.options.logger(
+            'error', `Encountered an error while migrating from ${prevVersion} to ${destVersion}`);
           throw e;
         }
       }


### PR DESCRIPTION
Sometimes versions don't match index values. This can make the error
output misleading when this happens. This patch fixes that so in the
error scenario we print the correct version label and not the index
value.