### PR TITLE
 #74: optional options to customize mongodb connection added

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,15 +30,18 @@ migrator.config({
       logIfLatest: true,
       // migrations collection name. Defaults to 'migrations'
       collectionName: 'migrations',
-      // mongdb url or mongo Db instance
-      db: "your connection string",
-      // optional mongdb Client options
-      dbOptions: {
-        useNewUrlParser: true,
-        useUnifiedTopology: true,
-      },
-      // optional database, in case using it in connection string is not an option
-      dbName: "your database name",
+      // mongdb connection properties object or mongo Db instance
+      db: {
+        // mongdb connection url
+        connectionUrl: "your connection string",
+        // optional database name, in case using it in connection string is not an option
+        name: "your database name",
+        // optional mongdb Client options
+        options: {
+          useNewUrlParser: true,
+          useUnifiedTopology: true,
+        },
+      }
 }); // Returns a promise
 
 ```
@@ -59,15 +62,18 @@ var migrator = new Migration({
       logIfLatest: true,
       // migrations collection name
       collectionName: 'migrations',
-      // mongdb url or mongo Db instance
-      db: "your connection string",
-      // optional mongdb Client options
-      dbOptions: {
-        useNewUrlParser: true,
-        useUnifiedTopology: true,
-      },
-      // optional database, in case using it in connection string is not an option
-      dbName: "your database name"
+      // mongdb connection properties object or mongo Db instance
+      db: {
+        // mongdb connection url
+        connectionUrl: "your connection string",
+        // optional database name, in case using it in connection string is not an option
+        name: "your database name",
+        // optional mongdb Client options
+        options: {
+          useNewUrlParser: true,
+          useUnifiedTopology: true,
+        },
+      }
 })
 await migrator.config(); // Returns a promise
 ```
@@ -200,12 +206,15 @@ migrator.config({
   logIfLatest: true,
   // migrations collection name to use in the database
   collectionName: "migrations"
-  // mongdb url or mongo Db instance
-  db: "your connection string",
-  // optional mongdb Client options
-  dbOptions: null,
-  // optional database, in case using it in connection string is notan option
-  dbName: null
+      // mongdb connection properties object or mongo Db instance
+  db: {
+    // mongdb connection url
+    connectionUrl: "your connection string",
+    // optional database name, in case using it in connection string is not an option
+    name: null,
+    // optional mongdb Client options
+    options: null,
+  }
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ migrator.config({
       collectionName: 'migrations',
       // mongdb url or mongo Db instance
       db: "your connection string",
+      // optional mongdb Client options
+      dbOptions: {
+        useNewUrlParser: true,
+        useUnifiedTopology: true,
+      },
+      // optional database, in case using it in connection string is not an option
+      dbName: "your database name",
 }); // Returns a promise
 
 ```
@@ -54,6 +61,13 @@ var migrator = new Migration({
       collectionName: 'migrations',
       // mongdb url or mongo Db instance
       db: "your connection string",
+      // optional mongdb Client options
+      dbOptions: {
+        useNewUrlParser: true,
+        useUnifiedTopology: true,
+      },
+      // optional database, in case using it in connection string is not an option
+      dbName: "your database name"
 })
 await migrator.config(); // Returns a promise
 ```
@@ -188,6 +202,10 @@ migrator.config({
   collectionName: "migrations"
   // mongdb url or mongo Db instance
   db: "your connection string",
+  // optional mongdb Client options
+  dbOptions: null,
+  // optional database, in case using it in connection string is notan option
+  dbName: null
 });
 ```
 

--- a/test/test.spec.ts
+++ b/test/test.spec.ts
@@ -13,7 +13,7 @@ describe('Migration', () => {
         log: true,
         logIfLatest: true,
         collectionName: '_migration',
-        db: dbURL,
+        db: { connectionUrl: dbURL },
       });
       await migrator.config();
     } catch (e) {


### PR DESCRIPTION
Allows a more customizable way to connect to mongodb client. dbName is needed in some cases when connecting to hosted mongodb instances. See this issue for reference: https://github.com/Automattic/mongoose/issues/8381